### PR TITLE
Compile Error Fixes

### DIFF
--- a/java-enet-wrapper-native/java-enet-wrapper-native/Makefile
+++ b/java-enet-wrapper-native/java-enet-wrapper-native/Makefile
@@ -7,7 +7,7 @@ SOURCES := org_bespin_enet_Event.c \
 
 OBJECTS := $(SOURCES:.c=.o)
 SYSTEM := $(shell uname -s)
-CFLAGS=-g -O2 -Iinclude
+CFLAGS=-g -O2 -Iinclude -fPIC
 CC=gcc
 CCLD=$(CC)
 LIBS := -lenet

--- a/java-enet-wrapper/java-enet-wrapper/build.xml
+++ b/java-enet-wrapper/java-enet-wrapper/build.xml
@@ -36,7 +36,7 @@
     	</jar>
 	</target>
 	<target name="compile">
-    	<javac srcdir="src" destdir="bin">
+       <javac srcdir="src/main/java" destdir="bin">
     	    <include name="org/bespin/enet/*.java" />
     	</javac>
 	</target>


### PR DESCRIPTION
This PR fixes fPIC problems when generating a SO files on x86_64 and points to the correct location of enet sources. Should fix the ant run on the Top level directory.
